### PR TITLE
Check image extension before loading

### DIFF
--- a/SkinManagerMod/Main.cs
+++ b/SkinManagerMod/Main.cs
@@ -346,6 +346,8 @@ namespace SkinManagerMod
 
             foreach (var file in files)
             {
+                if (!StbImage.IsSupportedExtension(file.Extension))
+                    continue;
                 string fileName = Path.GetFileNameWithoutExtension(file.Name);
 
                 foreach (var cmp in cmps)

--- a/SkinManagerMod/StbImage.cs
+++ b/SkinManagerMod/StbImage.cs
@@ -21,6 +21,12 @@ namespace SkinManagerMod
             public int componentCount;
         }
 
+        public static bool IsSupportedExtension(string extension)
+        {
+            var ext = extension.ToLowerInvariant();
+            return ext == ".jpeg" || ext == ".png" || ext == ".jpg";
+        }
+
         public static ImageInfo GetImageInfo(string filename)
         {
             bool success = GetImageInfo(filename, out uint x, out uint y, out uint comp) != 0;


### PR DESCRIPTION
Avoid erroring out when encountering GIMP .xcf, Photoshop .psd, .tiff, and whatever else people include in their skin mod distributions.