### PR TITLE
Fix DDS header

### DIFF
--- a/SkinManagerMod/SkinManagerMod.csproj
+++ b/SkinManagerMod/SkinManagerMod.csproj
@@ -71,7 +71,7 @@
       <HintPath>D:\Games\SteamLibrary\steamapps\common\Derail Valley\DerailValley_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" />
-    <Reference Include="UnityModManager, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL" />
+    <Reference Include="UnityModManager" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CarPatches.cs" />

--- a/SkinManagerMod/TextureLoader.cs
+++ b/SkinManagerMod/TextureLoader.cs
@@ -180,6 +180,9 @@ namespace SkinManagerMod
                 stream.Write(pixelFormat, 0, pixelFormat.Length);
                 // dwCaps = COMPLEX | MIPMAP | TEXTURE
                 stream.Write(BitConverter.GetBytes(0x401008), 0, 4);
+                // dwCaps2, dwCaps3, dwCaps4, dwReserved2
+                for (int i = 0; i < 4; i++)
+                   stream.Write(BitConverter.GetBytes(0), 0, 4);
 
                 if (needsDXGIHeader)
                     stream.Write(DDSHeaderDXT10(textureFormat), 0, DDS_HEADER_DXT10_SIZE);


### PR DESCRIPTION
Some missing fields from the base DDS_HEADER was causing the DDS_HEADER_DXT10 to start in the wrong place, preventing cached BC5 textures from ever being read successfully from cache.