### PR TITLE
Reapply Skins on Reload

### DIFF
--- a/SkinManagerMod/CommsRadioSkinSwitcher.cs
+++ b/SkinManagerMod/CommsRadioSkinSwitcher.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
 using DV;
 using DV.Customization.Paint;
 using DV.ThingTypes;
@@ -9,7 +7,6 @@ using DV.UserManagement;
 using HarmonyLib;
 using SMShared;
 using UnityEngine;
-using static DV.Common.GameFeatureFlags;
 
 #nullable disable
 namespace SkinManagerMod
@@ -348,11 +345,13 @@ namespace SkinManagerMod
                             if (!SkinProvider.IsBuiltInTheme(SelectedSkin) && (SelectedSkin.name == CurrentThemeName.exterior))
                             {
                                 SkinProvider.ReloadSkin(SelectedCar.carLivery.id, SelectedSkin.name);
-                            }
-                            else
-                            {
+                                var tempSkin = SelectedSkin.assetName;
+                                SelectedSkin = SkinProvider.GetBaseTheme(SMShared.Json.BaseTheme.DVRT);
                                 ApplySelectedSkin();
+                                SelectedSkin = SkinProvider.GetSkinsForType(SelectedCar.carLivery).First(x => x.name == tempSkin);
                             }
+
+                            ApplySelectedSkin();
                             ResetState();
                         }
                         CommsRadioController.PlayAudioFromRadio(ConfirmSound, transform);
@@ -372,11 +371,13 @@ namespace SkinManagerMod
                         if ((AlreadyPainted == AreaToPaint) && !SkinProvider.IsBuiltInTheme(SelectedSkin))
                         {
                             SkinProvider.ReloadSkin(SelectedCar.carLivery.id, SelectedSkin.name);
-                        }
-                        else
-                        {
+                            var tempSkin = SelectedSkin.assetName;
+                            SelectedSkin = SkinProvider.GetBaseTheme(SMShared.Json.BaseTheme.DVRT);
                             ApplySelectedSkin();
+                            SelectedSkin = SkinProvider.GetSkinsForType(SelectedCar.carLivery).First(x => x.name == tempSkin);
                         }
+
+                        ApplySelectedSkin();
                         CommsRadioController.PlayAudioFromRadio(ConfirmSound, transform);
                     }
 

--- a/SkinManagerMod/CommsRadioSkinSwitcher.cs
+++ b/SkinManagerMod/CommsRadioSkinSwitcher.cs
@@ -344,11 +344,7 @@ namespace SkinManagerMod
                             // for regular cars, skip area selection
                             if (!SkinProvider.IsBuiltInTheme(SelectedSkin) && (SelectedSkin.name == CurrentThemeName.exterior))
                             {
-                                SkinProvider.ReloadSkin(SelectedCar.carLivery.id, SelectedSkin.name);
-                                var tempSkin = SelectedSkin.assetName;
-                                SelectedSkin = SkinProvider.GetBaseTheme(SMShared.Json.BaseTheme.DVRT);
-                                ApplySelectedSkin();
-                                SelectedSkin = SkinProvider.GetSkinsForType(SelectedCar.carLivery).First(x => x.name == tempSkin);
+                                ReloadAndPrepareApplySelectedSkin();
                             }
 
                             ApplySelectedSkin();
@@ -370,11 +366,7 @@ namespace SkinManagerMod
                         // clicked on the selected car again, this means confirm
                         if ((AlreadyPainted == AreaToPaint) && !SkinProvider.IsBuiltInTheme(SelectedSkin))
                         {
-                            SkinProvider.ReloadSkin(SelectedCar.carLivery.id, SelectedSkin.name);
-                            var tempSkin = SelectedSkin.assetName;
-                            SelectedSkin = SkinProvider.GetBaseTheme(SMShared.Json.BaseTheme.DVRT);
-                            ApplySelectedSkin();
-                            SelectedSkin = SkinProvider.GetSkinsForType(SelectedCar.carLivery).First(x => x.name == tempSkin);
+                            ReloadAndPrepareApplySelectedSkin();
                         }
 
                         ApplySelectedSkin();
@@ -478,6 +470,21 @@ namespace SkinManagerMod
                     }
                 }
             }
+        }
+
+        private void ReloadAndPrepareApplySelectedSkin()
+        {
+            // Reload the skin.
+            SkinProvider.ReloadSkin(SelectedCar.carLivery.id, SelectedSkin.name);
+            // Store the original skin's name.
+            var tempSkin = SelectedSkin.assetName;
+            // Apply the default skin as a middle step to force it to update.
+            SelectedSkin = SkinProvider.GetBaseTheme(SMShared.Json.BaseTheme.DVRT);
+            ApplySelectedSkin();
+            // Refresh the current skins to use the updated version.
+            // No need to reset the index as no skins were added/removed.
+            SkinsForCarType = SkinProvider.GetSkinsForType(SelectedCar.carLivery);
+            SelectedSkin = SkinsForCarType.First(x => x.name == tempSkin);
         }
 
         private void SetSelectedSkin(CustomPaintTheme theme)

--- a/SkinManagerMod/Main.cs
+++ b/SkinManagerMod/Main.cs
@@ -3,7 +3,6 @@ using DV;
 using DV.Localization;
 using DV.ThingTypes;
 using HarmonyLib;
-using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using UnityEngine;
@@ -11,7 +10,6 @@ using SMShared;
 using DVLangHelper.Runtime;
 using SkinManagerMod.Items;
 using System.Collections;
-using SkinManagerMod.Patches;
 
 namespace SkinManagerMod
 {


### PR DESCRIPTION
When reloading a skin, automatically apply it, instead of needing the player to change to another paint and back manually.