### PR TITLE
B99.4 Compatibility Fixes

### DIFF
--- a/SkinManagerMod/Patches/PaintSprayerPatches.cs
+++ b/SkinManagerMod/Patches/PaintSprayerPatches.cs
@@ -3,6 +3,7 @@ using DV.Interaction;
 using DV.InventorySystem;
 using DV.Items;
 using HarmonyLib;
+using UnityEngine;
 
 namespace SkinManagerMod.Patches
 {
@@ -27,23 +28,31 @@ namespace SkinManagerMod.Patches
                 target.CurrentTheme = ___insertedCan.theme;
             }
             __instance.UnUse();
+            __instance.ignoreMagazineChange = true;
+            __instance.magazine.RemoveItem(0, activateItem: true, dropItem: true);
+            __instance.ignoreMagazineChange = false;
 
             // empty can
             if (paintCan.emptyCanPrefab != null)
             {
-                Reloadable reloadable = UnityEngine.Object.Instantiate(paintCan.emptyCanPrefab);
-                RespawnOnDrop component = reloadable.GetComponent<RespawnOnDrop>();
-                if (component != null)
+                GameObject emptyCan = Object.Instantiate(paintCan.emptyCanPrefab, __instance.unloadAnchor.transform.position, __instance.unloadAnchor.transform.rotation).gameObject;
+                RespawnOnDrop comp = emptyCan.GetComponent<RespawnOnDrop>();
+                if (comp != null)
                 {
-                    component.respawnOnDropThroughFloor = false;
-                    component.ignoreDistanceFromSpawnPosition = true;
+                    comp.respawnOnDropThroughFloor = false;
+                    comp.ignoreDistanceFromSpawnPosition = true;
                 }
-                reloadable.GetComponent<InventoryItemSpec>().BelongsToPlayer = true;
-                __instance.socket.Inserted = reloadable;
+                emptyCan.GetComponent<InventoryItemSpec>().BelongsToPlayer = true;
+                __instance.ignoreMagazineChange = true;
+                __instance.magazine.AddItem(emptyCan, 0);
+                __instance.ignoreMagazineChange = false;
+                __instance.insertedCan = emptyCan.GetComponent<PaintCan>();
+                __instance.paintSprayerEffects.OnInserted(emptyCan.transform, playSound: false);
+                __instance.paintSprayerEffects.OnSpent();
             }
             else
             {
-                __instance.socket.Inserted = null;
+                __instance.insertedCan = null;
             }
             Inventory.Instance.DestroyItem(paintCan.gameObject);
 

--- a/SkinManagerMod/SkinProvider.cs
+++ b/SkinManagerMod/SkinProvider.cs
@@ -629,6 +629,7 @@ namespace SkinManagerMod
                 customDefaultTheme.assetName = existingTheme.assetName;
                 customDefaultTheme.name = existingTheme.name;
                 customDefaultTheme.nameLocalizationKey = existingTheme.nameLocalizationKey;
+                customDefaultTheme.isStrippedSurface = existingTheme.isStrippedSurface;
                 customDefaultTheme.substitutions = existingTheme.substitutions;
 
                 foreach (var carType in Globals.G.Types.Liveries)
@@ -641,7 +642,7 @@ namespace SkinManagerMod
                     else if ((themeName == PrimerThemeName) && !IsThemeable(carType))
                     {
                         // extend primer coverage to all cars
-                        var defaultSkin = Skin.Default(carType.id, themeType);
+                        var defaultSkin = Skin.Primer(carType.id, themeType);
                         string bodyName = DefaultTextures.GetBodyTextureName(carType.id);
                         defaultSkin.SkinTextures.Add(new SkinTexture(bodyName, primerTexture));
                         customDefaultTheme.AddSkin(defaultSkin);

--- a/SkinManagerMod/Skins.cs
+++ b/SkinManagerMod/Skins.cs
@@ -16,33 +16,40 @@ namespace SkinManagerMod
         public readonly string Name;
         public readonly string? Path;
         public readonly bool IsDefault;
+        public readonly bool IsStrippedSurface;
         public readonly List<SkinTexture> SkinTextures = new();
         public readonly string[]? ResourcePaths;
         public readonly BaseTheme BaseTheme;
 
-        private Skin(string liveryId, string name, string? directory, bool isDefault, string[]? resourcePaths, BaseTheme baseTheme)
+        private Skin(string liveryId, string name, string? directory, bool isDefault, bool isStrippedSurface, string[]? resourcePaths, BaseTheme baseTheme)
         {
             LiveryId = liveryId;
             Name = name;
             Path = directory;
             IsDefault = isDefault;
+            IsStrippedSurface = isStrippedSurface;
             ResourcePaths = resourcePaths;
             BaseTheme = baseTheme;
         }
 
         public static Skin Custom(string liveryId, string name, string directory, BaseTheme baseTheme, string[]? resourcePaths = null)
         {
-            return new Skin(liveryId, name, directory, false, resourcePaths, baseTheme);
+            return new Skin(liveryId, name, directory, false, false, resourcePaths, baseTheme);
         }
 
         public static Skin Custom(SkinConfig config)
         {
-            return new Skin(config.CarId, config.Name, config.FolderPath, false, config.ResourcePaths, config.BaseTheme);
+            return new Skin(config.CarId, config.Name, config.FolderPath, false, false, config.ResourcePaths, config.BaseTheme);
         }
 
         public static Skin Default(string liveryId, BaseTheme baseTheme)
         {
-            return new Skin(liveryId, GetDefaultSkinName(liveryId), null, true, null, baseTheme);
+            return new Skin(liveryId, GetDefaultSkinName(liveryId), null, true, false, null, baseTheme);
+        }
+
+        public static Skin Primer(string liveryId, BaseTheme baseTheme)
+        {
+            return new Skin(liveryId, GetDefaultSkinName(liveryId), null, true, true, null, baseTheme);
         }
 
         public bool ContainsTexture(string name)

--- a/SkinManagerMod/TextureUtility.cs
+++ b/SkinManagerMod/TextureUtility.cs
@@ -34,6 +34,8 @@ namespace SkinManagerMod
             public static readonly string ModularT4 = "_t4";
             public static readonly string ModularT4MSO = "_t4_mso";
             public static readonly string ModularT4Normal = "_t4_normal";
+            public static readonly string ModularTint = "_tint1";
+            public static readonly string ModularT4Offset = "_t4_offset";
 
             public static readonly string[] UniqueTextures =
             {
@@ -57,6 +59,25 @@ namespace SkinManagerMod
             {
                 DetailAlbedo, DetailNormal,
             };
+
+            public static string[] GetPropertiesToCopyIfNull(Texture? texture, string propName)
+            {
+                if (texture != null)
+                {
+                    return new string[0];
+                }
+
+                if (propName == MetalGlossMap)
+                {
+                    return new[]
+                    {
+                        Metallic,
+                        Smoothness
+                    };
+                }
+
+                return new string[0];
+            }
         }
 
         /// <summary>
@@ -333,16 +354,6 @@ namespace SkinManagerMod
 
             var defaultMaterial = defaultData.GetMaterialForBaseTheme(skin.BaseTheme);
 
-            // Set scales etc
-            if (defaultMaterial.HasProperty(PropNames.Metallic))
-            {
-                float metallic = defaultMaterial.GetFloat(PropNames.Metallic);
-                mat.SetFloat(PropNames.Metallic, metallic);
-
-                float smoothness = defaultMaterial.GetFloat(PropNames.Smoothness);
-                mat.SetFloat(PropNames.Smoothness, smoothness);
-            }
-
             if (defaultMaterial.HasProperty(PropNames.DetailNormalScale))
             {
                 float intensity = defaultMaterial.GetFloat(PropNames.DetailNormalScale);
@@ -367,6 +378,12 @@ namespace SkinManagerMod
                         {
                             mat.SetTexture(PropNames.OcclusionMap, skinTexture.TextureData);
                         }
+
+                        if (mat.HasProperty(PropNames.Metallic))
+                        {
+                            mat.SetFloat(PropNames.Metallic, mat.GetFloat(PropNames.Metallic));
+                            mat.SetFloat(PropNames.Smoothness, mat.GetFloat(PropNames.Smoothness));
+                        }
                     }
                 }
                 else
@@ -386,12 +403,21 @@ namespace SkinManagerMod
                             mat.color = defaultMaterial.color;
                         }
 
-                        if (defaultTexture.PropertyName == PropNames.MetalGlossMap)
+                        // attempted to fix railbus and be2 primer glossiness issue, doesnt work...
+                        if (defaultTexture.PropertyName == PropNames.MetalGlossMap && mat.HasProperty(PropNames.Metallic))
                         {
-                            if (skinTexture && !GetMaterialTexture(mat, PropNames.OcclusionMap))
-                            {
-                                mat.SetTexture(PropNames.OcclusionMap, skinTexture);
-                            }
+                            mat.SetFloat(PropNames.Metallic, mat.GetFloat(PropNames.Metallic));
+                            mat.SetFloat(PropNames.Smoothness, mat.GetFloat(PropNames.Smoothness));
+                        }
+
+                        if ((defaultTexture.PropertyName == PropNames.ModularT1) && mat.HasProperty(PropNames.ModularTint))
+                        {
+                            mat.SetVector(PropNames.ModularTint, defaultMaterial.GetVector(PropNames.ModularTint));
+                        }
+
+                        if ((defaultTexture.PropertyName == PropNames.ModularT4) && mat.HasProperty(PropNames.ModularT4Offset))
+                        {
+                            mat.SetFloat(PropNames.ModularT4Offset, defaultMaterial.GetFloat(PropNames.ModularT4Offset));
                         }
                     }
                 }


### PR DESCRIPTION
These changes fix a compatibility issue caused by changes to how reloadable items work. Tested in game and confirmed to be functioning properly. Usable mod ZIP here: [SkinManager.zip](https://github.com/user-attachments/files/19924268/SkinManager.zip)
- Reworked ReloadableSocket patches to patch ItemContainer instead.
- Paint sprayer patches now utilize the new magazine system.
- Fixed DM1U Clean DVRT and Demonstrator interiors having dirty specular, and DM1U Demonstrator interior having incorrectly colored walls.

There are known and unresolved bugs in among these changes. Attempts to fix have been made but unsuccessful:
- Skin Manager primer (applied via remote) doesn't actually function as a primer when applied not on "regular cars".
- Clean DVRT painted DM1U and Short Flatbed, and BE2 primer interior, has full glossiness. Most likely caused by the base material having no metallic maps.