### PR TITLE
B99.4h5 Compatibility Fix

### DIFF
--- a/SkinManagerMod/CarMaterialData.cs
+++ b/SkinManagerMod/CarMaterialData.cs
@@ -21,7 +21,7 @@ namespace SkinManagerMod
 
                 BaseTheme themeType = SkinProvider.GetThemeTypeByName(defaultTheme.name);
 
-                foreach (var substitute in defaultTheme.substitutions.Concat(defaultTheme.minorSubstitutions))
+                foreach (var substitute in defaultTheme.substitutions)
                 {
                     if (!substitute.substitute) continue;
 

--- a/SkinManagerMod/Patches/PaintCanPatches.cs
+++ b/SkinManagerMod/Patches/PaintCanPatches.cs
@@ -2,6 +2,7 @@
 using DV.Interaction;
 using DV.ThingTypes;
 using HarmonyLib;
+using UnityEngine;
 
 namespace SkinManagerMod.Patches
 {
@@ -20,8 +21,23 @@ namespace SkinManagerMod.Patches
 
         [HarmonyPatch(nameof(PaintCan.CheckPaintApplicationValidity))]
         [HarmonyPostfix]
-        public static void FixAlreadyPaintedValidity(ref PaintCan.Validity __result, PaintTheme themeFrom, TrainCar target)
+        public static void FixAlreadyPaintedValidity(PaintCan __instance, ref PaintCan.Validity __result, PaintTheme themeFrom, TrainCar target)
         {
+            if (__instance.theme.isStrippedSurface && themeFrom.IsStrippedSurface)
+            {
+                __result = PaintCan.Validity.AlreadyPainted;
+                return;
+            }
+
+            if (__instance.theme is CustomPaintTheme customTheme)
+            {
+                if (!customTheme.SupportsVehicle(target.carLivery))
+                {
+                    __result = PaintCan.Validity.Incompatible;
+                    return;
+                }
+            }
+
             if ((__result == PaintCan.Validity.Incompatible) && themeFrom)
             {
                 if (CarTypes.IsRegularCar(target.carLivery) || themeFrom.IsStrippedSurface)

--- a/SkinManagerMod/SkinProvider.cs
+++ b/SkinManagerMod/SkinProvider.cs
@@ -631,7 +631,7 @@ namespace SkinManagerMod
                 customDefaultTheme.nameLocalizationKey = existingTheme.nameLocalizationKey;
                 customDefaultTheme.isStrippedSurface = existingTheme.isStrippedSurface;
                 customDefaultTheme.substitutions = existingTheme.substitutions;
-                customDefaultTheme.minorSubstitutions = existingTheme.minorSubstitutions;
+                customDefaultTheme.forbiddenLiveries = existingTheme.forbiddenLiveries;
 
                 foreach (var carType in Globals.G.Types.Liveries)
                 {


### PR DESCRIPTION
These changes fix a compatibility issue introduced in B99.4 hotfix 5, caused by changes to paint can substitutions. Tested in game and confirmed to be working. Usable mod zip here: [SkinManager.zip](https://github.com/user-attachments/files/20160960/SkinManager.zip)

- Removed minorSubstitutions references, added forbiddenLiveries
- Can no longer sand SM primer
- Fixed being able to apply SM paint on incompatible cars
